### PR TITLE
Better keyboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,12 +36,14 @@ function App() {
           <Puzzles wordlist={wordlist} working={working} guesslist={guesslist} />
           <Keyboard onKeyPress={(key) => {
             if(key === '-') setWorking((tmp) => tmp.slice(0, tmp.length-1));
-            else if(key === '+' && working.length === 5 && checkValidity(working)) {
-              // lets go.
-              const newGuesslist = guesslist.concat([working]);
-              setGuesslist(newGuesslist);
-              setWorking('');
-              setWordlist(sortByValue(wordlist, newGuesslist));
+            else if(key === '+') {
+              if(working.length === 5 && checkValidity(working)) {
+                // lets go.
+                const newGuesslist = guesslist.concat([working]);
+                setGuesslist(newGuesslist);
+                setWorking('');
+                setWordlist(sortByValue(wordlist, newGuesslist));
+              }
             } else if(working.length !== 5) {
               setWorking((tmp) => tmp + key);
             }

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -21,11 +21,11 @@ const Content = styled.div`
 const Row = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: center;
 `;
 
-const Key = styled.div`
-  width: 40px;
+const Key = styled.div<{letter: string}>`
+  width: ${({ letter }) => (letter === '+') ? '55px' : '40px'};
   height: 40px;
   font-size: 24px;
   display: flex;
@@ -33,6 +33,8 @@ const Key = styled.div`
   align-items: center;
   border: 1px solid rgba(0,0,0,0.3);
   border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
 `;
 
 const rows = ['qwertyuiop','asdfghjkl','+zxcvbnm-'];
@@ -44,7 +46,7 @@ function Keyboard({ onKeyPress }: { onKeyPress: (key: string) => void}) {
         {rows.map((row) => (
           <Row key={row}>
             {row.split('').map((letter) => (
-              <Key key={letter} onClick={() => onKeyPress(letter)}>{letter === '+' ? 'GO' : letter === '-' ? '<-' : letter}</Key>
+              <Key key={letter} letter={letter} onClick={() => onKeyPress(letter)}>{letter === '+' ? 'GO' : letter === '-' ? '⌫' : letter}</Key>
             ))}
 
           </Row>

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -35,7 +35,7 @@ const Key = styled.div`
   border-radius: 10px;
 `;
 
-const rows = ['qwuertyuiop','asdfghjkl','+zxcvbnm-'];
+const rows = ['qwertyuiop','asdfghjkl','+zxcvbnm-'];
 
 function Keyboard({ onKeyPress }: { onKeyPress: (key: string) => void}) {
   return (


### PR DESCRIPTION
A number of keyboard changes and bugfixes:

* Removes duplicate `u` key
* Makes sure GO button does not add `+` when guess is incomplete
* Ensures the keyboard is using "pointer" icon instead of text select and disallow select
* Changes the visual layout a bit:
  * Makes "GO" button wider
  * Removes gaps within row

Before:
![kilordle_before](https://user-images.githubusercontent.com/1549691/154973118-4c76bb3c-6eb9-4eff-bd64-78b875ab6ca3.png)

After:
![kilordle_after](https://user-images.githubusercontent.com/1549691/154973142-4f6a1a6d-72b6-402e-a810-0451596aac74.png)

