### PR TITLE
don't accept space in letter-slots

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
       setGuesslist(newGuesslist);
       setWorking('');
       setWordlist(sortByValue(wordlist, newGuesslist));
-    } else if(working.length !== 5 && key.length === 1) {
+    } else if(working.length !== 5 && key.length === 1 && key !== ' ') {
       setWorking((tmp) => tmp + key.toLowerCase());
     }
   }


### PR DESCRIPTION
Fixes #15. Although if the maintainer(s) are deeply opposed to the use of space/shift-space to scroll the page up and down I won't be mortally wounded if this doesn't get merged. It should be pretty easy to review