### PR TITLE
End Screen Upgrade

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,15 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="font"
+      href="https://fonts.gstatic.com/s/oxygen/v14/2sDcZG1Wl4LcnbuCJW8zaGW5.woff2"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
     <title>Kilordle</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,20 @@ function App() {
   //   }
   // }, []);
 
+  useEffect(() => {
+    if (!window.FontFace) return;
+    // ugly, but the only way i could find to initialize the font in preparation
+    // for it being used in the end screen canvas drawing except for actually
+    // using it on the page
+    const font = new FontFace(
+      'Oxygen',
+      'url(https://fonts.gstatic.com/s/oxygen/v14/2sDcZG1Wl4LcnbuCJW8zaGW5.woff2)'
+    );
+    font.load().then(() => {
+      document.fonts.add(font);
+    });
+  }, []);
+
   return (
     <div className="App">
       <Container>

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -197,6 +197,10 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
   /** try to activate the system's built-in share menu; returns true on success */
   const mobileShareResults = async (png: Blob): Promise<boolean> => {
     if (!("share" in navigator)) return false;
+    // Chrome and Edge on Windows 10 support the navigator.share API but
+    // tragically, the resulting pop-up is very bad, unless you really want your
+    // results emailed. So we will keep this method mobile-focused
+    if (navigator.userAgent.includes("Windows")) return false;
     const shareable: ShareData = {
       files: [new File([png], getFileName(), { type: "image/png" })]
     };

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -32,6 +32,7 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
   const maxColumns = 50;
   const actualColumns = Math.min(maxColumns, guesses);
   const rows = 25;
+  const fontFamily = "Oxygen, sans-serif";
 
   const mmts = {
     // measurements
@@ -71,8 +72,6 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     canvas.height = mmts.height;
     const context = canvas.getContext('2d');
     if (!context) return;
-    console.log('drawing to canvas');
-    console.log('progress history is', progressHistory);
     // draw background (white)
     context.fillStyle = '#ffffff';
     context.fillRect(0, 0, canvas.width, canvas.height);
@@ -83,15 +82,14 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     context.fillStyle = '#000000';
     context.textAlign = 'center';
     context.textBaseline = 'top';
-    context.font = `${mmts.fontSize * 1.5}px sans-serif`;
+    context.font = `${mmts.fontSize * 1.5}px ${fontFamily}`;
     context.fillText(
       `I beat Kilordle in ${guesses} guesses :')`,
       mmts.width / 2,
       0
     );
     context.translate(0, mmts.fontSize * 1.5);
-    // setup fonts, colors
-    context.font = `${mmts.fontSize}px sans-serif`;
+    context.font = `${mmts.fontSize}px ${fontFamily}`;
     // draw numbers
     context.textBaseline = 'alphabetic';
     context.textAlign = 'right';
@@ -123,7 +121,7 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     // draw url of site
     context.textBaseline = 'middle';
     context.textAlign = 'center';
-    context.font = `${mmts.urlHeight}px sans-serif`;
+    context.font = `${mmts.urlHeight}px ${fontFamily}`;
     context.fillText(
       'https://jonesnxt.github.io/kilordle/',
       mmts.leftGutter + mmts.gridWidth / 2,
@@ -182,17 +180,17 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
 
   /** try to copy results to clipboard; returns true on success */
   const copyResults = async (png: Blob): Promise<boolean> => {
-      try {
+    try {
       await navigator.clipboard
-          .write([
-            new ClipboardItem({
+        .write([
+          new ClipboardItem({
             [png.type]: png,
-            }),
-          ])
+          }),
+        ])
     } catch {
       return false;
     }
-            setButtonText('Copied to clipboard');
+    setButtonText('Copied to clipboard');
     return true;
   }
 
@@ -206,10 +204,10 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     try {
       await navigator.share(shareable);
       return true;
-      } catch {
+    } catch {
       return false;
-      }
     }
+  }
 
   const shareResults = async () => {
     if (!canvasResult.current) return;

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -130,7 +130,18 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
       mmts.nonTitleHeight - mmts.margin
     );
     // draw grid of squares
-    context.fillStyle = '#0fb30f';
+    const gradient = context.createRadialGradient(
+      mmts.gridLeftEdge + 3 / 4 * mmts.gridWidth,
+      mmts.gridHeight - mmts.gridHeight / 4,
+      mmts.gridHeight / 6,
+      mmts.gridLeftEdge + 3 / 4 * mmts.gridWidth,
+      mmts.gridHeight - mmts.gridHeight / 4,
+      mmts.gridHeight
+    );
+    gradient.addColorStop(0, "#22b512");
+    gradient.addColorStop(0.4, "#2bb31d");
+    gradient.addColorStop(1, "#218c16");
+    context.fillStyle = gradient;
     const drawnSquareSide = mmts.squareSide - mmts.squarePadding * 2;
     const finalHeight = progressHistory[progressHistory.length - 1];
     for (let x = 0; x < actualColumns; x++) {

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -28,7 +28,7 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
 
   const displayWidth = 525;
   const titleHeight = 20;
-  const displayHeight = 250 + titleHeight;
+  const displayHeight = 275 + titleHeight;
   const maxColumns = 50;
   const actualColumns = Math.min(maxColumns, guesses);
   const rows = 25;
@@ -39,7 +39,8 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     nonTitleHeight: displayHeight - titleHeight,
     width: displayWidth,
     leftGutter: 30,
-    bottomGutter: 15,
+    bottomGutter: 30,
+    urlHeight: 15,
     margin: 3,
     lineWidth: 1,
     fontSize: 10,
@@ -97,7 +98,7 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     context.fillText(
       '0',
       mmts.leftGutter - mmts.margin,
-      mmts.nonTitleHeight - mmts.margin
+      mmts.nonTitleHeight - mmts.margin - mmts.urlHeight
     );
     context.textBaseline = 'top';
     context.fillText('1000', mmts.leftGutter - mmts.margin, mmts.margin);
@@ -106,23 +107,23 @@ function EndScreen({ progressHistory }: { progressHistory: number[] }) {
     context.fillText(
       String(guesses),
       mmts.gridLeftEdge +
-        actualColumns * mmts.squareSide +
-        mmts.squarePadding -
-        mmts.squareSide / 2,
-      mmts.nonTitleHeight - mmts.margin
+      actualColumns * mmts.squareSide +
+      mmts.squarePadding -
+      mmts.squareSide / 2,
+      mmts.nonTitleHeight - mmts.margin - mmts.urlHeight
     );
     // draw axes
-    context.fillRect(mmts.leftGutter, 0, mmts.lineWidth, mmts.nonTitleHeight);
+    context.fillRect(mmts.leftGutter, 0, mmts.lineWidth, mmts.nonTitleHeight - mmts.urlHeight);
     context.fillRect(
       mmts.leftGutter / 2,
       mmts.nonTitleHeight - mmts.bottomGutter,
-      mmts.width - mmts.leftGutter,
+      mmts.width - mmts.leftGutter / 2,
       mmts.lineWidth
     );
     // draw url of site
     context.textBaseline = 'middle';
     context.textAlign = 'center';
-    context.font = `${mmts.fontSize * 1.25}px sans-serif`;
+    context.font = `${mmts.urlHeight}px sans-serif`;
     context.fillText(
       'https://jonesnxt.github.io/kilordle/',
       mmts.leftGutter + mmts.gridWidth / 2,


### PR DESCRIPTION
The pull request sequel that no-one asked for... We've got:

1. Support for the navigator.share API through the share button, which will bring up the "share" prompt built into the current OS/browser. I've disabled this on Windows because although it's supported the built-in prompt is very bad:
![image](https://user-images.githubusercontent.com/49729978/163351596-2dfd477e-7d41-45ef-94ed-44d84c8a6715.png)
2. The image filename now has the game's date in it.
3. The site URL is moved down somewhat; before, when people beat the game in very few guesses, their guess count x-axis label could collide with the URL ([example](https://twitter.com/CoachBehnfeldt/status/1511027196952993802?s=20&t=YXXpzMUm-hmK4l_sClkt5w))
4. I added the "Oxygen" font from the Google font cloud to the canvas and made a subtle radial gradient for the squares' color. I'm not married to that particular font but I do think it looks better than the default browser sans-serif.

Result:
![image](https://user-images.githubusercontent.com/49729978/163352029-e1789683-3083-475d-a9b7-d7584557bf69.png)

The only thing that's still bugging me is I feel like some kind of creative background or pattern could be added behind the grid to fill in the blank space... something with a lot of squares rotated at weird angles, maybe, I am not a graphic design pro

Thanks for letting me participate in the Wordle craze in some small way, I've never experienced anything like searching on Twitter and seeing people post a graphic that I developed, even a simple one. You do not have to accept this pull request, although I hope you do, I just had a couple of things at the back of my mind all this time that I wanted to improve about my previous work.