### PR TITLE
Improve contrast of used keys in the keyboard.

### DIFF
--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -41,7 +41,7 @@ const Key = styled.div<{letter: string, used: boolean}>`
 
   
   ${({ used }) => used && `
-    background-color: #EEE;  
+    background-color: #CCC;  
   `}
 `;
 


### PR DESCRIPTION
On my screen, I can barely tell the difference unless I look at the keyboard from a different angle. Using a slightly darker shade makes it much clearer and doesn't make it any harder to read the letters.

Before:

![2022-04-19T11:52:29,124385900-05:00](https://user-images.githubusercontent.com/6611767/164055409-a08621bd-b4ef-45d2-bb46-2f1fc95ebafc.png)

After:

![2022-04-19T11:51:50,175027065-05:00](https://user-images.githubusercontent.com/6611767/164055319-901d7368-f35a-4b2e-92a1-fe500862495c.png)
