### PR TITLE
fix multiple words per guess issue

### DIFF
--- a/src/util/sortByValue.ts
+++ b/src/util/sortByValue.ts
@@ -2,11 +2,24 @@ export function sortByValue(words: string[], guesses: string[]) {
   // iterate through each word and give it a score
   let scores = words.map((word) => scoreWordle(word, guesses));
 
-  return scores
-    .map<[string, number]>((score, i) => [words[i], score])
-    .filter((p) => p[1] !== 15)
-    .sort((a, b) => b[1] - a[1])
-    .map((k) => k[0])
+  let mappedScores = scores.map<[string, number]>((score, i) => [words[i], score])
+
+  let filteredScores = mappedScores.filter((p) => p[1] !== 15)
+
+  let filteredBlargScores = mappedScores.filter((p) => p[1] === 15)
+  console.log(filteredBlargScores)
+
+  let sortedScores = filteredScores.sort((a, b) => b[1] - a[1])
+
+  let mappedAgainScores = sortedScores.map((k) => k[0])
+
+  return mappedAgainScores
+
+  // return scores
+  //   .map<[string, number]>((score, i) => [words[i], score])
+  //   .filter((p) => p[1] !== 15)
+  //   .sort((a, b) => b[1] - a[1])
+  //   .map((k) => k[0])
 }
 
 export function scoreWordle(word: string, guesses: string[]) {

--- a/src/util/sortByValue.ts
+++ b/src/util/sortByValue.ts
@@ -2,28 +2,16 @@ export function sortByValue(words: string[], guesses: string[]) {
   // iterate through each word and give it a score
   let scores = words.map((word) => scoreWordle(word, guesses));
 
-  let mappedScores = scores.map<[string, number]>((score, i) => [words[i], score])
-
-  let filteredScores = mappedScores.filter((p) => p[1] !== 15)
-
-  let filteredBlargScores = mappedScores.filter((p) => p[1] === 15)
-  console.log(filteredBlargScores)
-
-  let sortedScores = filteredScores.sort((a, b) => b[1] - a[1])
-
-  let mappedAgainScores = sortedScores.map((k) => k[0])
-
-  return mappedAgainScores
-
-  // return scores
-  //   .map<[string, number]>((score, i) => [words[i], score])
-  //   .filter((p) => p[1] !== 15)
-  //   .sort((a, b) => b[1] - a[1])
-  //   .map((k) => k[0])
+  return scores
+    .map<[string, number]>((score, i) => [words[i], score])
+    .filter((p) => p[1] !== 100)
+    .sort((a, b) => b[1] - a[1])
+    .map((k) => k[0])
 }
 
 export function scoreWordle(word: string, guesses: string[]) {
-  // yeah I know
+  if (guesses.includes(word)) return 100;
+
   return word.split('').reduce((acc, letter, i) => 
     acc + guesses.reduce((best, guess) => 
       Math.max(best, letter === guess[i] ? 3 : (guess.includes(letter) ? 1 : 0)),


### PR DESCRIPTION
resolves https://github.com/jonesnxt/kilordle/issues/23

in order to diagnose this, i expanded 
https://github.com/jonesnxt/kilordle/blob/acae1a0b698549d134a3d2b1d300f18d6308d9fd/src/util/sortByValue.ts#L5-L9
out to be
https://github.com/jonesnxt/kilordle/blob/7275b3d0f640c6cf95e5590a74b7e069209f1fff/src/util/sortByValue.ts#L1-L23

then i played a bit, at which point i noticed 
![image](https://user-images.githubusercontent.com/70942617/167240935-5094dd31-69c6-492b-888a-ed00a7a00846.png)

instead of trying to understand the scoring system, i just made `scoreWordle` return `100` if the word is in `guesses`, and changed the `!== 15` to be `!== 100`